### PR TITLE
fix: Add try/catches/failsafes for abnormal responses to papertrailHttpReporter.js

### DIFF
--- a/lib/reporters/papertrailHttpReporter.js
+++ b/lib/reporters/papertrailHttpReporter.js
@@ -1,10 +1,12 @@
 import { processMessage } from '../syslogConvertor/rfc5424.js'
+import { consoleReporter } from '../reporters/consoleReporter.js'
 
 export const createPapertrailHttpReporter = (token, fetchClient, extraData = {}) => {
   return async logQueue => {
     const batch = logQueue.map(msgObject => {
       return processMessage({ ...msgObject, ...extraData })
     }).join('\n')
+    
     return fetchClient('https://logs.collector.solarwinds.com/v1/logs', {
       body: batch,
       method: 'POST',
@@ -12,6 +14,12 @@ export const createPapertrailHttpReporter = (token, fetchClient, extraData = {})
         'content-type': 'application/json',
         Authorization: `Basic ${btoa(':' + token)}`
       }
+    }).then(response => {
+      if(response.status !== 200) {
+        consoleReporter({ level: 50, msg: response.statusText })
+      }
+    }).catch(error => {
+      consoleReporter({ level: 50, msg: error })
     })
   }
 }


### PR DESCRIPTION
Closes: https://github.com/autotelic/newco-skipper-otto-tracker/issues/176

When paper trail fails to send a response, fasdentify is crashing. 
This PR adds a catch block to the papertrailReporter to handle invalid responses gracefully.

Test Plan:
1. Go to fasdentify-gateway > index.js
2. Look for `transportsByEnv` initialization
3. Set `development = deployedTransports` (similar to staging, uat, production)
4. Go to fasdentify-gateway > package.json
5. set dependencies to
```
"dependencies": {
    "@autotelic/miniflare-runner": "~0.2.1",
    "@autotelic/worker-logger": "git@github.com:autotelic/worker-logger.git#fix/unhandled_papertrail_response_errors",
    "@autotelic/worker-request-handlers": "^0.12.0",
    "itty-router": "~2.4.4",
    "itty-router-extras": "~0.4.2"
  }
```
6. From terminal, fasdentify-gateway run `npm i`
7. Go to fasdentify-gateway  > wrangler.toml
8. Under the [vars] section, update the `PAPERTRAIL_TOKEN = "Zw-6DEIwz28KovGHTP2iQ1P68HnF"`
9. Restart the gateway `npm run miniflare`
10. Open Postman or similar app
11. Send a POST request to `http://local.fasdentify.com:8757/api/accounts`
12. Check the fasdentify-gateway console. There should be no errors from the papertrail fetch appearing.
13. Note that `POST /api/accounts 400 Bad Request` is from our API. (This is fine) 
14. update the `PAPERTRAIL_TOKEN = "INVALID"`
15. Restart gateway
16. Resend the POST request
17. `ERROR: Unauthorized` Should appear in the logs
18. Go to node_modules > @autotelic/worker-logger/lib/reporters/papertrailHttpReporter.js
19. change the url from the fetchClient to `https://logs.collector.solarwinds.comzzzzz/v1/logs` to simulate downtime wherein the papertrail could not send a response back.
20. Restart gateway
21. Resend the POST request
22. From console, you should have `ERROR: TypeError: fetch failed` displayed. (Without the added catch block, This makes the fasdentify crash)